### PR TITLE
Set tpx_tag

### DIFF
--- a/src/gromacs/fileio/tpxio.cpp
+++ b/src/gromacs/fileio/tpxio.cpp
@@ -92,7 +92,7 @@
  * merging with mainstream GROMACS, set this tag string back to
  * TPX_TAG_RELEASE, and instead add an element to tpxv.
  */
-static const std::string tpx_tag = TPX_TAG_RELEASE;
+static const std::string tpx_tag = "RAMD";
 
 /*! \brief Enum of values that describe the contents of a tpr file
  * whose format matches a version number


### PR DESCRIPTION
This fork builds tpr files with modified format.
If those tpr files are read with a more recent version of
unmodified GROMACS, it crashes with no information why.
With this change, the output will point to the reason why
the crash happens.